### PR TITLE
Added job ticket generation based on given date

### DIFF
--- a/src/modules/jobs/controllers/jobs.controller.ts
+++ b/src/modules/jobs/controllers/jobs.controller.ts
@@ -11,8 +11,8 @@ export class JobsController {
       'flowStatusMessage': "Invalid request path. Path must include 'jobs/get/:uuid'"
     }
   }
-  @Get(['get/:uuid', '/get/:uuid/:amount'])
-  async getJobsSpecific(@Param('uuid') uuid: string, @Param('amount') amount: string) {
+  @Get(['get/:uuid/:date', '/get/:uuid/:date/:amount'])
+  async getJobsSpecific(@Param('uuid') uuid: string, @Param('date') date: string, @Param('amount') amount: string) {
     await new Promise(resolve => setTimeout(resolve, 500)); // just adds a delay for feel so request isn't instantaneous.
     
     if (!uuid || !uuid.match(/^[a-z]{2}\d{3}[a-z\d]$/i)) { // regex checks for valid uuid
@@ -23,12 +23,15 @@ export class JobsController {
     }
 
     // Doesn't matter if amount is undefined or a non-number, parseInt will just return NaN which is then handled by TechLoad. The second value is an optional variable so in the case that amount is NaN then it is still handled the same, as a falsy value.
-    const jobData: TechLoad = new TechLoad(uuid, Number.parseInt(amount));
+    const jobData: TechLoad = new TechLoad(uuid, date, Number.parseInt(amount));
     
     return {
       'flowStatus': 'SUCCESS',
       'flowStatusMessage': '',
-      'jobs': jobData.jobs // only passes array of jobs to save on response packet size
+      'jobs': jobData.jobs, // only passes array of jobs to save on response packet size
+      'date': jobData.getDate(),
+      'uuid': jobData.getUUID(),
+      'count': jobData.getJobCount()
     }
   }
 }

--- a/src/modules/jobs/models/tech-load.model.ts
+++ b/src/modules/jobs/models/tech-load.model.ts
@@ -2,23 +2,47 @@ export class TechLoad {
 
   public  jobs: JobData[];
   private jobCount: number;
-  private uuid: string;
 
   private seed: number;
   private seedIndex: number = 0; // doesn't really matter what it's instantiated to, just needs to be any number >= 0 so the seed methods can generate the next number
 
-  constructor(uuid: string, amount?: number) { // Can be built with a given amount, but if not will seed the number of jobs to build
-    this.uuid = uuid;
+  constructor(private uuid: string, private date: string, amount?: number) { // Can be built with a given amount, but if not will seed the number of jobs to build
     // uses abs as ensure the seed is positive. convertStrToNum sometimes returns a negative value, and the seed increments positively so must start >= 0 or else may create predictable seeded number (i.e. 0 * anything is always 0)
-    this.seed = Math.abs(this.convertStrToNum(uuid));
+    this.seed = Math.abs(this.convertStrToNum(uuid + date));
     
     this.jobs = [];
     // generate a random number of jobs, weighted towards ~3
     const generatedJobCount: number = Math.round( (this.nextRand()*7 + this.nextRand()*7) / 2 );  // This line needs to run regardless of if we were passed an amount, or else the seeded rng will get messed up!
     this.jobCount = amount ? amount : generatedJobCount; // allows for front end to request a specific number of jobs. If amount is not present, use the above generated number
     for (let i = 0; i < this.jobCount; i++) {
+      this.seed = Math.abs(this.convertStrToNum(uuid + date + '/' + i)); // re-seeds for every job, so changes to the number of rand calls in one job won't impact future jobs. Without this, each job is generated from the same series of seeded numbers
+      this.seedIndex = 0;
       this.jobs.push(this.generateJob()); // Where all the "magic" happens, generateJob will create all job data and push it into job array
     }
+  }
+
+  /**
+   * @description Getter for uuid used for job generation
+   * @returns The used UUID
+   */
+  public getUUID(): string {
+    return this.uuid;
+  }
+
+  /**
+   * @description Getter for date used for job generation
+   * @returns The used date
+   */
+  public getDate(): string {
+    return this.date;
+  }
+
+  /**
+   * @description Getter for job count
+   * @returns The number of jobs generated
+   */
+  public getJobCount(): number {
+    return this.jobCount;
   }
 
   /**


### PR DESCRIPTION
Before, the job list was the same every day, and so the only way to get different jobs was to change the UUID. With this update, jobs are now generated based on both the UUID and the date provided by the front end.

Also implemented a fix for job seeding being used between jobs, ie each job was generated from the same string of randomly generated numbers of the same seed. This would cause an issue where if you added some new feature to a job, it would shift all the seeded numbers down, and every bit of data generated after the first job would now be different. This fix is done by re-seeding the RNG after each job. Now you can generate any number of random numbers each ticket and future tickets won't be impacted.

Also added a bit of extra data to the payload sent to the front end, which may be of use for other future features.

DO NOT MERGE WITHOUT FRONTEND PR: https://github.com/micah-wehrle/ng-atlas/pull/2

Adjusted files:
jobs.controller.ts
tech-load.model.ts